### PR TITLE
Added fast_math file with approximated tanh function

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 
 	<script src="./scripts/main.js"></script>
 
+	<script src="./lib/fast_math.js"></script>
 
 	<script src="./scripts/init.js"></script>
 </body>

--- a/lib/fast_math.js
+++ b/lib/fast_math.js
@@ -1,0 +1,10 @@
+function approximate_tanh(x) {
+    if ( x < -3 ) {
+        return -1;
+    } else if( x > 3 ) {
+        return 1;
+    } else {
+        var xSq = x * x;
+        return x * (27 + xSq) / (27 + 9 * xSq);
+    }
+}

--- a/scripts/brain.js
+++ b/scripts/brain.js
@@ -159,7 +159,7 @@ Creature.prototype.feedForward = function (input) {
 				if (brain == "forget" || brain == "modify" || brain == "main") {
 					nbrain.neurons[layer + 1][axon] = 1 / (1 + Math.exp(-value)); // set neuron in next layer value to sigmoid
 				} else {
-					nbrain.neurons[layer + 1][axon] = Math.tanh(value); // set neuron in next layer value to tanh
+					nbrain.neurons[layer + 1][axon] = approximate_tanh(value); // set neuron in next layer value to tanh
 				}
 			}
 		}
@@ -172,7 +172,7 @@ Creature.prototype.feedForward = function (input) {
 	for (let i = 0; i < cellStateLength; i++) {
 		network.cellState[i] *= forgetOutput[i];
 		network.cellState[i] += decideOutput[i] * modifyOutput[i];
-		network.output[i] *= Math.tanh(network.cellState[i]);
+		network.output[i] *= approximate_tanh(network.cellState[i]);
 	}
 
 	return network.output;


### PR DESCRIPTION
In testing this made the feedForward() method go from taking up 10% of the total time to 7%
[Here's a jsperf test showing a comparison](https://jsperf.com/math-tanh-vs-approximated/1)
[Here's a graph showing the difference between the 2 functions](https://www.desmos.com/calculator/gbfbkurj7f)
Numbers bigger than +/-3 are clamped to +/-1